### PR TITLE
[DO NOT MERGE] Remove jh alias to use jh cli instead

### DIFF
--- a/jhipster.plugin.zsh
+++ b/jhipster.plugin.zsh
@@ -1,4 +1,3 @@
-alias jh='yo jhipster'
 alias jhyarn='yo jhipster --yarn'
 alias jhskip='yo jhipster --skip-install'
 alias jhinstall='npm install && bower install && gulp install'


### PR DESCRIPTION
Related to JHipster CLI https://github.com/jhipster/generator-jhipster/pull/5726

This PR need to be merged only for the next release and if JHipster CLI is merged.
So there will not be any conflicts